### PR TITLE
Convex hull

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,8 @@ set(CLANG_COVERAGE_COMPILE_FLAGS
 set(CMAKE_CXX_FLAGS "-g -O0")
 
 set (SRC
-        src/misc.cpp)
+        src/misc.cpp
+        src/convex_hull.cpp)
 
 set(MZALG "_mz_algos")
 add_library(${MZALG} ${SRC})

--- a/inc/convex_hull.h
+++ b/inc/convex_hull.h
@@ -1,0 +1,25 @@
+#ifndef MZ_CONVEX_HULL_
+#define MZ_CONVEX_HULL_
+
+#include <vector>
+
+namespace mz {
+
+struct vec
+{
+    constexpr vec() = default;
+    constexpr vec(int x, int y) noexcept : x_(x), y_(y) {}
+    int x_ = 0;
+    int y_ = 0;
+};
+
+inline bool operator==(vec const& lhs, vec const& rhs) noexcept
+{
+    return lhs.x_ == rhs.x_ && lhs.y_ == rhs.y_;
+}
+
+std::vector<vec> convex_hull(std::vector<vec> const& vecSet);
+
+}
+
+#endif  // !MZ_CONVEX_HULL_

--- a/inc/convex_hull.h
+++ b/inc/convex_hull.h
@@ -13,9 +13,14 @@ struct vec
     int y_ = 0;
 };
 
-inline bool operator==(vec const& lhs, vec const& rhs) noexcept
+constexpr inline bool operator==(vec const& lhs, vec const& rhs) noexcept
 {
     return lhs.x_ == rhs.x_ && lhs.y_ == rhs.y_;
+}
+
+constexpr inline vec operator-(vec const& lhs, vec const& rhs)
+{
+    return vec{lhs.x_ - rhs.x_, lhs.y_ - rhs.y_};
 }
 
 std::vector<vec> convex_hull(std::vector<vec> const& vecSet);

--- a/src/convex_hull.cpp
+++ b/src/convex_hull.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <list>
+#include <stdexcept>
 
 #include "convex_hull.h"
 
@@ -20,6 +22,38 @@ std::vector<vec>& sort_unique(std::vector<vec>& v)
     return v;
 }
 
+bool right_turn(std::list<vec> const& v)
+{
+    if (v.size() > 2) {
+        auto c = v.rbegin();
+        auto b = std::next(c);
+        auto a = std::next(b);
+
+        vec v1 = *b - *a;
+        vec v2 = *c - *b;
+
+        return (v1.x_ * v2.y_ - v1.y_ * v2.x_) < 0;
+    }
+    throw std::runtime_error("right_turn: list size < 3");
+}
+
+std::list<vec> compute_hull(std::vector<vec> const& v)
+{
+    if (v.size() > 2) {
+        std::list<vec> hull{v[0], v[1]};
+
+        for (size_t i = hull.size(); i < v.size(); ++i) {
+            hull.push_back(v[i]);
+            while (hull.size() > 2 && !right_turn(hull)) {
+                auto lastButOne = std::prev(std::prev(hull.end()));
+                hull.erase(lastButOne);
+            }
+        }
+        return hull;
+    }
+    throw std::runtime_error("compute_hull: vector size < 3");
+}
+
 }  // namespace mz
 
 namespace mz {
@@ -27,8 +61,18 @@ namespace mz {
 std::vector<vec> convex_hull(std::vector<vec> const& vecSet)
 {
     if (vecSet.size() > 3) {
-        // std::vector<vec> hull{vecSet};
-        // hull = sort_unique(hull);
+        std::vector<vec> vecUniqueSorted{vecSet};
+        vecUniqueSorted = sort_unique(vecUniqueSorted);
+
+        auto upperHull = compute_hull(vecUniqueSorted);
+
+        std::reverse(vecUniqueSorted.begin(), vecUniqueSorted.end());
+        auto lowerHull = compute_hull(vecUniqueSorted);
+
+        for (auto it = std::next(lowerHull.begin()); it != std::prev(lowerHull.end()); ++it)
+            upperHull.push_back(*it);
+
+        return std::vector<vec>{upperHull.begin(), upperHull.end()};
     }
     return std::vector<vec>{vecSet};
 }

--- a/src/convex_hull.cpp
+++ b/src/convex_hull.cpp
@@ -1,0 +1,36 @@
+#include <algorithm>
+
+#include "convex_hull.h"
+
+namespace mz {
+
+std::vector<vec>& sort_unique(std::vector<vec>& v)
+{
+    auto customCompr = [](vec a, vec b) {
+        if (a.x_ == b.x_)
+            return a.y_ <= b.y_;
+        return a.x_ < b.x_;
+    };
+
+    if (!std::is_sorted(v.begin(), v.end(), customCompr))
+        std::sort(v.begin(), v.end(), customCompr);
+
+    v.erase(std::unique(v.begin(), v.end()), v.end());
+
+    return v;
+}
+
+}  // namespace mz
+
+namespace mz {
+
+std::vector<vec> convex_hull(std::vector<vec> const& vecSet)
+{
+    if (vecSet.size() > 3) {
+        // std::vector<vec> hull{vecSet};
+        // hull = sort_unique(hull);
+    }
+    return std::vector<vec>{vecSet};
+}
+
+}  // namespace mz

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(algos_ut "MZ_ALGOS_UT")
 
 set(TEST_SRC
+        test_convex_hull.cpp
         test_misc_gcd.cpp
         test_misc_qs.cpp)
 

--- a/test/test_convex_hull.cpp
+++ b/test/test_convex_hull.cpp
@@ -1,4 +1,6 @@
 #include <gtest/gtest.h>
+#include <algorithm>
+#include <list>
 #include "convex_hull.h"
 
 using namespace mz;
@@ -6,7 +8,10 @@ using namespace mz;
 namespace mz {
 
 std::vector<vec>& sort_unique(std::vector<vec>& v);
-}
+bool right_turn(std::list<vec> const& l);
+std::list<vec> compute_hull(std::vector<vec> const& v);
+
+}  // namespace mz
 
 TEST(VEC, EqualsToOperator)
 {
@@ -16,6 +21,82 @@ TEST(VEC, EqualsToOperator)
 
     EXPECT_FALSE(vecA == vecB);
     EXPECT_TRUE(vecA == vecC);
+}
+
+TEST(VEC, SubtractionOperator)
+{
+    const vec vecA{-4, 1};
+    const vec vecB{-1, 1};
+    const vec resultAB{-3, 0};
+    const vec resultBA{3, 0};
+
+    EXPECT_EQ(vecA - vecB, resultAB);
+    EXPECT_EQ(vecB - vecA, resultBA);
+}
+
+TEST(RightTurn, ThrowsIfListSizeLT3)
+{
+    std::list<vec> list_sz0;
+    std::list<vec> list_sz1(1);
+    std::list<vec> list_sz2(2);
+
+    EXPECT_THROW(right_turn(list_sz0), std::runtime_error);
+    EXPECT_THROW(right_turn(list_sz1), std::runtime_error);
+    EXPECT_THROW(right_turn(list_sz2), std::runtime_error);
+}
+
+TEST(RightTurn, HandlesListSizeGT2WithNoRightTurn)
+{
+    const std::list<vec> list_sz3{{-4, 1}, {-3, 0}, {-1, 1}};
+    const std::list<vec> list_sz4{{-4, 1}, {-3, -1}, {-3, 0}, {-3, 2}};
+
+    EXPECT_FALSE(right_turn(list_sz3));
+    EXPECT_FALSE(right_turn(list_sz4));
+}
+
+TEST(RightTurn, HandlesListSizeGT2WithRightTurn)
+{
+    const std::list<vec> list_sz3{{-3, -1}, {-3, 0}, {-2, 0}};
+    const std::list<vec> list_sz4{{-4, 1}, {-3, -1}, {-3, 0}, {-1, 1}};
+
+    EXPECT_TRUE(right_turn(list_sz3));
+    EXPECT_TRUE(right_turn(list_sz4));
+}
+
+TEST(ComputeHull, HandlesVectorSizeLT3)
+{
+    std::vector<vec> vec_sz0;
+    std::vector<vec> vec_sz1(1);
+    std::vector<vec> vec_sz2(2);
+
+    EXPECT_THROW(compute_hull(vec_sz0), std::runtime_error);
+    EXPECT_THROW(compute_hull(vec_sz1), std::runtime_error);
+    EXPECT_THROW(compute_hull(vec_sz2), std::runtime_error);
+}
+
+TEST(ComputeHull, HandlesVectorSizeGT2)
+{
+    std::vector<vec> vec_sz3{{-4, 1}, {-3, 0}, {-3, 2}};
+    const std::list<vec> expectedResult_sz3{{-4, 1}, {-3, 2}};
+    std::vector<vec> vec_sz6{{-4, 1}, {-3, -1}, {-3, 0}, {-3, 2}, {-2, 0}, {-1, 1}};
+    const std::list<vec> expectedResult_sz6{{-4, 1}, {-3, 2}, {-1, 1}};
+
+    EXPECT_EQ(compute_hull(vec_sz3), expectedResult_sz3);
+    EXPECT_EQ(compute_hull(vec_sz6), expectedResult_sz6);
+}
+
+TEST(ComputeHull, HandlesReversedVector)
+{
+    std::vector<vec> vec_sz3{{-4, 1}, {-3, 0}, {-3, 2}};
+    const std::list<vec> expectedResult_sz3{{-3, 2}, {-3, 0}, {-4, 1}};
+    std::reverse(vec_sz3.begin(), vec_sz3.end());
+
+    std::vector<vec> vec_sz6{{-4, 1}, {-3, -1}, {-3, 0}, {-3, 2}, {-2, 0}, {-1, 1}};
+    const std::list<vec> expectedResult_sz6{{-1, 1}, {-3, -1}, {-4, 1}};
+    std::reverse(vec_sz6.begin(), vec_sz6.end());
+
+    EXPECT_EQ(compute_hull(vec_sz3), expectedResult_sz3);
+    EXPECT_EQ(compute_hull(vec_sz6), expectedResult_sz6);
 }
 
 TEST(SortUnique, HandlesEmptyVector)
@@ -95,4 +176,20 @@ TEST(ConvexHull, CanHandleVectorSizeLT4)
 
     cvxResult = convex_hull(cvx_sz3);
     EXPECT_EQ(cvx_sz3, cvxResult);
+}
+
+TEST(ConvexHull, CanHandleVectorSizeGT3)
+{
+    const std::vector<vec> cvx_sz4{{-4, 1}, {-1, 1}, {-3, -1}, {-3, 0}};
+    const std::vector<vec> expectedHull_sz4{{-4, 1}, {-1, 1}, {-3, -1}};
+
+    const std::vector<vec> cvx_sz9{{0, 0}, {-1, -1}, {1, 1},  {-1, 1}, {1, -1},
+                                   {1, 0}, {-1, 0},  {0, -1}, {0, 1}};
+    const std::vector<vec> expectedHull_sz9{{-1, -1}, {-1, 1}, {1, 1}, {1, -1}};
+
+    auto cvxResult = convex_hull(cvx_sz4);
+    EXPECT_EQ(cvxResult, expectedHull_sz4);
+
+    cvxResult = convex_hull(cvx_sz9);
+    EXPECT_EQ(cvxResult, expectedHull_sz9);
 }

--- a/test/test_convex_hull.cpp
+++ b/test/test_convex_hull.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+#include "convex_hull.h"
+
+using namespace mz;
+
+namespace mz {
+
+std::vector<vec>& sort_unique(std::vector<vec>& v);
+}
+
+TEST(VEC, EqualsToOperator)
+{
+    const vec vecA{1, 2};
+    const vec vecB{2, 1};
+    const vec vecC{1, 2};
+
+    EXPECT_FALSE(vecA == vecB);
+    EXPECT_TRUE(vecA == vecC);
+}
+
+TEST(SortUnique, HandlesEmptyVector)
+{
+    std::vector<vec> cvx;
+    cvx = sort_unique(cvx);
+
+    EXPECT_TRUE(cvx.empty());
+}
+
+TEST(SortUnique, HandlesOneElemVector)
+{
+    std::vector<vec> cvx(1);
+    const auto cvxCopy{cvx};
+
+    cvx = sort_unique(cvx);
+    EXPECT_EQ(cvx, cvxCopy);
+}
+
+TEST(SortUnique, HandlesAlreadySortedVectorUnique)
+{
+    std::vector<vec> cvx{{-3, 1}, {-2, -1}, {-2, 0}, {1, 4}};
+    auto cvxCopy{cvx};
+    cvx = sort_unique(cvx);
+
+    EXPECT_EQ(cvx, cvxCopy);
+}
+
+TEST(SortUnique, HandlesUnsortedVector)
+{
+    std::vector<vec> cvx{{0, 0}, {-1, 3}, {3, 1}, {1, 2}, {-4, 2}, {-1, 2}};
+    auto cvxCopy{cvx};
+    std::vector<vec> cvxSorted{{-4, 2}, {-1, 2}, {-1, 3}, {0, 0}, {1, 2}, {3, 1}};
+
+    cvx = sort_unique(cvx);
+    EXPECT_NE(cvx, cvxCopy);
+    EXPECT_EQ(cvx, cvxSorted);
+}
+
+TEST(SortUnique, HandlesAlreadySortedVectorNotUnique)
+{
+    std::vector<vec> cvx{{-3, 1}, {-3, 1}, {-2, -1}, {-2, 0}, {1, 4}, {1, 4}};
+    auto cvxCopy{cvx};
+    std::vector<vec> cvxSorted{{-3, 1}, {-2, -1}, {-2, 0}, {1, 4}};
+
+    cvx = sort_unique(cvx);
+    EXPECT_NE(cvx, cvxCopy);
+    EXPECT_EQ(cvx, cvxSorted);
+}
+
+TEST(SortUnique, HandlesUnsortedVectorNotUnique)
+{
+    std::vector<vec> cvx{{0, 0}, {-1, 3}, {3, 1}, {3, 1}, {1, 2}, {-4, 2}, {-4, 2}, {-1, 2}};
+    std::vector<vec> cvxCopy{cvx};
+    std::vector<vec> cvxSorted{{-4, 2}, {-1, 2}, {-1, 3}, {0, 0}, {1, 2}, {3, 1}};
+
+    cvx = sort_unique(cvx);
+    EXPECT_NE(cvx, cvxCopy);
+    EXPECT_EQ(cvx, cvxSorted);
+}
+
+TEST(ConvexHull, CanHandleVectorSizeLT4)
+{
+    const std::vector<vec> cvx_sz0;
+    const std::vector<vec> cvx_sz1(1);
+    const std::vector<vec> cvx_sz2(2);
+    const std::vector<vec> cvx_sz3{{1, 0}, {-1, 0}, {0, 1}};
+
+    auto cvxResult = convex_hull(cvx_sz0);
+    EXPECT_EQ(cvx_sz0, cvxResult);
+
+    cvxResult = convex_hull(cvx_sz1);
+    EXPECT_EQ(cvx_sz1, cvxResult);
+
+    cvxResult = convex_hull(cvx_sz2);
+    EXPECT_EQ(cvx_sz2, cvxResult);
+
+    cvxResult = convex_hull(cvx_sz3);
+    EXPECT_EQ(cvx_sz3, cvxResult);
+}


### PR DESCRIPTION
Convex hull algorithm, in this first version, takes (un)sorted std::vector and returns sorted std::vector of coordinates that make up convex hull. It may be used in more advanced collision detection algorithm.

future possible TODOes:
- make algorithm more generic (ie. use templates instead of defined container or/and types, which now is std::vector<struct(int, int)>